### PR TITLE
Add docker compose to setup test & development environments DBs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,14 @@
 /node_modules
 /.pnp
 .pnp.js
+
+# environment
 .env*
+.env.development
+.env.test
+
+# docker provision
+/docker
 
 # testing
 /coverage
@@ -14,10 +21,6 @@
 
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
 
 npm-debug.log*
 yarn-debug.log*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+volumes:
+  messaging_app_mysql:
+    driver: root
+
+services:
+  messaging_app_mysql:
+    image: mysql:8.0.30
+    container_name: messaging_app_mysql
+    volumes:
+      - ./docker/provision/mysql/init:/docker-entrypoint-initdb.d
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+    ports:
+      - '${MYSQL_PORT}:3306'

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"db:generate": "drizzle-kit generate:mysql",
 		"db:deploy:production": "node --env-file=.env.production src/db/migrator.js",
 		"db:deploy:development": "node --env-file=.env.development src/db/migrator.js",
-		"db:deploy:test": "node --env-file=.env.test src/db/migrator.js"
+		"db:deploy:test": "node --env-file=.env.test src/db/migrator.js",
+		"docker-setup": "docker compose up --wait && printf \"> Waiting for service to be up and running ...\" && sleep 10 && npm run db:deploy:test && npm run db:deploy:development"
 	},
 	"author": "walter larrea",
 	"license": "ISC",


### PR DESCRIPTION
Running the command "npm run docker-setup" will run docker compose up, and will migrate the database schemas to it.
Be sure to run "npm run db:generate" if you haven't already done.